### PR TITLE
ci/check-status: see content

### DIFF
--- a/.github/workflows/checkstatus.yml
+++ b/.github/workflows/checkstatus.yml
@@ -6,7 +6,6 @@ on:
 jobs:
 
   Check-statuses:
-    if: ${{ contains(github.event.branches.*.name, 'master') == 1 }}
     runs-on: ubuntu-latest
     steps:
 
@@ -19,7 +18,7 @@ jobs:
         sha: ${{ github.event.sha }}
 
     - name: Upload artifact URL file
-      if: steps.check.outputs.skip != 'true'
+      if: (steps.check.outputs.skip != 'true') && contains(github.event.branches.*.name, 'master')
       uses: weslenng/gcp-storage-sync@master
       env:
         GCP_SERVICE_ACCOUNT_KEY_FILE: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY_FILE }}

--- a/.github/workflows/checkstatus.yml
+++ b/.github/workflows/checkstatus.yml
@@ -11,6 +11,9 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    - name: Print GitHub event
+      run: echo '${{ toJson(github.event) }}'
+
     - uses: ./.github/check-status
       id: check
       with:


### PR DESCRIPTION
This PR moves the branch condition to the last step, so that we can see what's the event/status data when the runs are skipped (most of the time). The JSON data is printed in a separate step.