### PR TITLE
Fix issues with constraining multiple PLL/MMCM for xc7

### DIFF
--- a/xc/common/utils/prjxray_create_place_constraints.py
+++ b/xc/common/utils/prjxray_create_place_constraints.py
@@ -9,6 +9,7 @@ import vpr_place_constraints
 import lxml.etree as ET
 import constraint
 import prjxray.db
+from collections import defaultdict
 
 CLOCKS = {
     "PLLE2_ADV_VPR":
@@ -116,7 +117,7 @@ CLOCKS = {
     "IBUF_VPR":
         {
             "sources": frozenset(("O", )),
-            "sinks": frozenset(),
+            "sinks": frozenset(("I", )),
             "type": "IBUF",
         },
     "IBUFDS_GTE2_VPR":
@@ -441,6 +442,11 @@ class ClockPlacer(object):
 
                 if sink_net not in self.input_pins and sink_net not in self.clock_sources:
 
+                    # Allow IBUFs. At this point we cannot distinguish between
+                    # IBUFs for clock and logic.
+                    if bel == "IBUF_VPR":
+                        continue
+
                     # Allow BUFGs to be driven by generic sources but only
                     # when enabled.
                     if bel == "BUFGCTRL_VPR" and allow_bufg_logic_sources:
@@ -544,19 +550,42 @@ class ClockPlacer(object):
         for clock_name in unused_blocks:
             del self.clock_blocks[clock_name]
 
+        exclusive_clocks = defaultdict(set)
+        ibuf_cmt_sinks = defaultdict(set)
+
         for net in self.clock_sources:
+
+            is_net_ibuf = False
+
+            if net not in self.input_pins:
+                source_clock_name = self.clock_sources_cname[net]
+                if source_clock_name not in unused_blocks:
+                    source_block = self.clock_blocks[source_clock_name]
+                    if CLOCKS[source_block['subckt']]['type'] == 'IBUF':
+                        is_net_ibuf = True
+
             for clock_name in self.clock_sources[net]:
+
+                if clock_name in unused_blocks:
+                    continue
+
                 clock = self.clock_blocks[clock_name]
 
                 if CLOCKS[clock['subckt']]['type'] == 'PLLE2_ADV':
                     problem.addConstraint(
                         lambda cmt: cmt in self.pll_cmts, (clock_name, )
                     )
+                    exclusive_clocks["PLLE2_ADV"].add(clock_name)
+                    if is_net_ibuf:
+                        ibuf_cmt_sinks[source_clock_name].add(clock_name)
 
                 if CLOCKS[clock['subckt']]['type'] == 'MMCME2_ADV':
                     problem.addConstraint(
                         lambda cmt: cmt in self.mmcm_cmts, (clock_name, )
                     )
+                    exclusive_clocks["MMCME2_ADV"].add(clock_name)
+                    if is_net_ibuf:
+                        ibuf_cmt_sinks[source_clock_name].add(clock_name)
 
                 if net in self.input_pins:
                     if CLOCKS[clock['subckt']]['type'] == 'BUFGCTRL':
@@ -566,7 +595,7 @@ class ClockPlacer(object):
                             lambda clock: clock == self.cmt_to_bufg_tile[
                                 self.input_pins[net]], (clock_name, )
                         )
-                    else:
+                    elif CLOCKS[clock['subckt']]['type'] != 'IBUF':
                         problem.addConstraint(
                             lambda clock: clock == self.input_pins[net],
                             (clock_name, )
@@ -587,15 +616,29 @@ class ClockPlacer(object):
                                 source] == sink_bufg,
                             (source_clock_name, clock_name)
                         )
-                    else:
+                    elif not is_net_ibuf:
                         problem.addConstraint(
                             lambda source, sink: source == sink,
                             (source_clock_name, clock_name)
                         )
 
+        # Ensure that in case of an IBUF driving multiple CMTs at least one of
+        # them is in the same clock region as the IBUF.
+        for source, sinks in ibuf_cmt_sinks.items():
+            problem.addConstraint(lambda s, *k: s in k, (
+                source,
+                *sinks,
+            ))
+
+        # Prevent constraining exclusive clock source sets to the same resource
+        for typ, clocks in exclusive_clocks.items():
+            problem.addConstraint(
+                constraint.AllDifferentConstraint(), list(clocks)
+            )
+
         if any_variable:
             solutions = problem.getSolutions()
-            assert len(solutions) > 0
+            assert len(solutions) > 0, "No solution found!"
 
             self.clock_cmts.update(solutions[0])
 
@@ -883,6 +926,7 @@ def main():
     parser.add_argument('--graph_limit', help='Graph limit parameters')
 
     args = parser.parse_args()
+    eprint(" ".join(sys.argv))
 
     part = args.part
     device_families = {

--- a/xc/common/utils/prjxray_create_place_constraints.py
+++ b/xc/common/utils/prjxray_create_place_constraints.py
@@ -926,7 +926,6 @@ def main():
     parser.add_argument('--graph_limit', help='Graph limit parameters')
 
     args = parser.parse_args()
-    eprint(" ".join(sys.argv))
 
     part = args.part
     device_families = {

--- a/xc/xc7/tests/mmcm/CMakeLists.txt
+++ b/xc/xc7/tests/mmcm/CMakeLists.txt
@@ -61,6 +61,7 @@ add_file_target(FILE mmcm_none_basys3_bottom.v SCANNER_TYPE verilog)
 add_file_target(FILE mmcm_buf_basys3_bottom.v SCANNER_TYPE verilog)
 add_file_target(FILE mmcm_ext_basys3_bottom.v SCANNER_TYPE verilog)
 add_file_target(FILE mmcm_int_frac_basys3_bottom.v SCANNER_TYPE verilog)
+add_file_target(FILE mmcm_dual.v SCANNER_TYPE verilog)
 
 add_fpga_target(
   NAME mmcm_packing
@@ -110,6 +111,13 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
+add_fpga_target(
+  NAME mmcm_dual_basys3
+  BOARD basys3-full
+  SOURCES mmcm_dual.v
+  INPUT_IO_FILE ${COMMON}/basys3.pcf
+  EXPLICIT_ADD_FILE_TARGET
+  )
 
 add_vivado_target(
   NAME mmcm_packing_vivado
@@ -157,6 +165,13 @@ add_vivado_target(
   CLOCK_PERIODS 10.0
   )
 
+add_vivado_target(
+  NAME mmcm_dual_basys3_vivado
+  PARENT_NAME mmcm_dual_basys3
+  CLOCK_PINS clk
+  CLOCK_PERIODS 10.0
+  )
+
 # =============================================================================
 
 set(TEST_TARGETS
@@ -166,6 +181,7 @@ set(TEST_TARGETS
   mmcm_int_frac_basys3
   mmcm_buf_basys3
   mmcm_ext_basys3
+  mmcm_dual_basys3
 )
 
 foreach(TEST_TARGET ${TEST_TARGETS})

--- a/xc/xc7/tests/mmcm/mmcm_dual.v
+++ b/xc/xc7/tests/mmcm/mmcm_dual.v
@@ -1,0 +1,80 @@
+// A test with two MMCMs that have feedback through BUFGs
+
+module top (
+    input  wire         clk,
+    input  wire         rx,
+    output wire         tx,
+    input  wire [15:0]  sw,
+    output wire [15:0]  led
+);
+
+// ==========================================================================--
+// Reset generator
+
+reg [7:0] rst_sr;
+wire      rst;
+
+always @(posedge clk)
+    rst_sr <= {1'b1, rst_sr[7:1]};
+
+assign rst = ~rst_sr[0];
+
+// ==========================================================================--
+// MMCM 1
+
+wire clk_1, clk_1_buf;
+wire clkfb_1, clkfb_1_buf;
+
+MMCME2_ADV # (
+    .CLKIN1_PERIOD      (10.0),
+    .CLKFBOUT_MULT_F    (8.00),
+    .CLKOUT0_DIVIDE_F   (24.0),
+    .COMPENSATION       ("ZHOLD")
+) mmcm_1 (
+    .RST        (rst),
+    .CLKIN1     (clk),
+    .CLKOUT0    (clk_1),
+    .CLKFBIN    (clkfb_1_buf),
+    .CLKFBOUT   (clkfb_1),
+    .PWRDWN     (1'b0),
+);
+
+BUFG bufg_1_1 (.I(clk_1),   .O(clk_1_buf));
+BUFG bufg_1_2 (.I(clkfb_1), .O(clkfb_1_buf));
+
+reg [21:0] cnt_1;
+always @(posedge clk_1_buf)
+    cnt_1 <= cnt_1 + 1;
+
+assign led[0] = cnt_1[21];
+
+// ==========================================================================--
+// MMCM 2
+
+wire clk_2, clk_2_buf;
+wire clkfb_2, clkfb_2_buf;
+
+MMCME2_ADV # (
+    .CLKIN1_PERIOD      (10.0),
+    .CLKFBOUT_MULT_F    (8.00),
+    .CLKOUT0_DIVIDE_F   (16.0),
+    .COMPENSATION       ("ZHOLD")
+) mmcm_2 (
+    .RST        (rst),
+    .CLKIN1     (clk),
+    .CLKOUT0    (clk_2),
+    .CLKFBIN    (clkfb_2_buf),
+    .CLKFBOUT   (clkfb_2),
+    .PWRDWN     (1'b0),
+);
+
+BUFG bufg_2_1 (.I(clk_2),   .O(clk_2_buf));
+BUFG bufg_2_2 (.I(clkfb_2), .O(clkfb_2_buf));
+
+reg [21:0] cnt_2;
+always @(posedge clk_2_buf)
+    cnt_2 <= cnt_2 + 1;
+
+assign led[1] = cnt_2[21];
+
+endmodule


### PR DESCRIPTION
This PR relaxes the constraint that enforces a `PLL`/`MMCM` and its driving `IBUF` to be in the same CMT region. This is required in case when a single `IBUF` drives more than one `PLL`/`MMCM`.

The constraint is relaxed in a way that among all `PLL`/`MMCM` driven by an `IBUF` at least one of them is required to be in the same CMT region. Therefore the change should not affect placement quality of existing designs.