### PR TITLE
[k4n8] Add VPR options to mimic legacy behavior

### DIFF
--- a/conda_lock.yml
+++ b/conda_lock.yml
@@ -78,7 +78,7 @@ dependencies:
   - tbb=2020.3=hfd86e86_0
   - tk=8.6.11=h1ccaba5_0
   - typing_extensions=3.10.0.2=pyh06a4308_0
-  - vtr-optimized=8.0.0_5105_g116f30cb8=20220114_081711
+  - vtr-optimized=8.0.0_5310_g08ec56b5d=20220317_162926
   - wheel=0.37.1=pyhd3eb1b0_0
   - xz=5.2.5=h7b6447c_0
   - yosys=0.13_4_g61324cf55=20220114_081711_py37

--- a/quicklogic/qlf_k4n8/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/CMakeLists.txt
@@ -21,7 +21,9 @@ set(VPR_ARCH_ARGS "\
     --place_delay_model delta_override \
     --router_lookahead extended_map \
     --allow_dangling_combinational_nodes on \
-    --absorb_buffer_luts off "
+    --absorb_buffer_luts off \
+    --post_synth_netlist_unconn_inputs nets \
+    --post_synth_netlist_unconn_outputs nets "
 )
 
 # Define the architecture


### PR DESCRIPTION
Since a PR has been merged to VPR which allows to control handling of unconnected ports when writing post-layout Verilog netlist additional control parameters have to be provided to maintain legacy behavior.