### PR TITLE
GCP package uploading

### DIFF
--- a/.github/ci/install.sh
+++ b/.github/ci/install.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
 INSTALL_DIR="$(pwd)/install"
+mkdir -p $INSTALL_DIR
+
+export CMAKE_FLAGS="-GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DINSTALL_FAMILIES=xc7"
+source $(dirname "$0")/setup-and-activate.sh
 
 heading "Installing gsutil"
 (
+    qpt -qqy update && qpt -qqy insall curl
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
     apt -qqy update && apt -qqy install google-cloud-cli
 )
 echo "----------------------------------------"
-
-export CMAKE_FLAGS="-GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DINSTALL_FAMILIES=xc7"
-
-source $(dirname "$0")/setup-and-activate.sh
 
 pushd build
 make_target install "Running install tests (make install)"
@@ -57,7 +58,7 @@ GCP_PATH=symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/
 
 heading "Uploading packages"
 (
-    if [ "$UPLOAD_PACKAGES" -ne 0 ]; then
+    if [ "$UPLOAD_PACKAGES" = "true" ]; then
         TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
         for package in $(ls *.tar.xz)
         do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ['docs', 'testarch', 'tests', 'ice40', 'xc7', 'xc7-vendor', 'xc7a200t', 'xc7a200t-vendor', 'install', 'ql']
+        test: ['docs', 'testarch', 'tests', 'ice40', 'xc7', 'xc7-vendor', 'xc7a200t', 'xc7a200t-vendor', 'ql']
     env:
       MAX_CORES: 80
       GHA_EXTERNAL_DISK: "tools"
@@ -24,6 +24,34 @@ jobs:
 
       - name: Execute test script
         run: stdbuf -i0 -o0 -e0 ./.github/ci/${{ matrix.test }}.sh
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          path: |
+            **/results*.gz
+            **/plot_*.svg
+
+  Install:
+    if: ${{ !(github.event_name != 'pull_request' && github.actor == 'dependabot[bot]') }}
+    container: ubuntu:bionic
+    runs-on: [self-hosted, Linux, X64]
+    needs: Test
+
+    env:
+      MAX_CORES: 80
+      GHA_EXTERNAL_DISK: "tools"
+      GHA_SA: "gh-sa-f4pga-arch-defs-ci"
+      UPLOAD_PACKAGES: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Execute test script
+        run: stdbuf -i0 -o0 -e0 ./.github/ci/install.sh
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}


### PR DESCRIPTION
Added package uploading to GCP but only from builds from the `main` branch.

Uploading has been tested by temporarily disabling the actual tests and enabling uploads from PRs which yielded in the test package: https://console.cloud.google.com/storage/browser/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/20220401-132741.

The actual package will be created and uploaded only upon merge.