### PR TITLE
xc/common/utils: allow to have less or equal IDELAYE2 than IDELAYCTRL

### DIFF
--- a/xc/common/utils/prjxray_create_place_constraints.py
+++ b/xc/common/utils/prjxray_create_place_constraints.py
@@ -1034,7 +1034,7 @@ def main():
 
     idelayctrl_instances = place_constraints.get_used_instances("IDELAYCTRL")
 
-    assert len(idelayctrl_cmts) == len(
+    assert len(idelayctrl_cmts) <= len(
         idelayctrl_instances
     ), "The number of IDELAYCTRL blocks and IO banks with IDELAYs used do not match."
 


### PR DESCRIPTION
Cherry-picked from #2003.