### PR TITLE
Revert "requirements: s/SymbiFlow/F4PGA/; do not require git"

### DIFF
--- a/.github/workflows/update_conda_lock.yml
+++ b/.github/workflows/update_conda_lock.yml
@@ -2,6 +2,7 @@ name: update_conda_lock
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,9 @@ tinyfpgab
 tinyprog
 yapf==0.26.0
 fasm
-https://github.com/QuickLogic-Corp/quicklogic-fasm/archive/57b6e60574a9d483dc94710d0d3ff42a62b4ec41.zip#quicklogic_fasm
-https://github.com/chipsalliance/f4pga-rr-graph/archive/master.zip#rr-graph
-https://github.com/chipsalliance/python-fpga-interchange/archive/master.zip#python-fpga-interchange
+git+https://github.com/QuickLogic-Corp/quicklogic-fasm.git@57b6e60574a9d483dc94710d0d3ff42a62b4ec41#egg=quicklogic_fasm
+git+https://github.com/SymbiFlow/symbiflow-rr-graph.git#egg=rr-graph
+git+https://github.com/SymbiFlow/python-fpga-interchange.git#egg=python-fpga-interchange
 -e third_party/prjxray
 -e third_party/xc-fasm
 -e third_party/qlf-fasm
@@ -41,6 +41,6 @@ https://github.com/chipsalliance/python-fpga-interchange/archive/master.zip#pyth
 third_party/pythondata-cpu-vexriscv
 third_party/pythondata-software-compiler_rt
 # Ibex dependencies
-https://github.com/lowRISC/edalize/archive/ot.zip#edalize
-https://github.com/lowRISC/fusesoc/archive/ot.zip#fusesoc
+git+https://github.com/lowRISC/edalize.git@ot
+git+https://github.com/lowRISC/fusesoc.git@ot
 mako


### PR DESCRIPTION
This reverts commit 9242920f0ae2837f4bad957b3afb359857a3d196.

There are some packages that use `setuptools-scm` to get the version of the package from either `git` or `metadata` (https://pypi.org/project/setuptools-scm/).