### PR TITLE
ci: print packages' timestamp in job 'install'

### DIFF
--- a/.github/ci/install.sh
+++ b/.github/ci/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 INSTALL_DIR="$(pwd)/install"
 mkdir -p $INSTALL_DIR
@@ -8,18 +8,18 @@ source $(dirname "$0")/setup-and-activate.sh
 
 heading "Installing gsutil"
 (
-    apt -qqy update && apt -qqy install curl
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-    apt -qqy update && apt -qqy install google-cloud-cli
+  apt -qqy update && apt -qqy install curl
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+  apt -qqy update && apt -qqy install google-cloud-cli
 )
 echo "----------------------------------------"
 
 heading "Set environment variables for F4PGA CLI utils"
 {
-	export F4PGA_FAM=xc7
-	export F4PGA_ENV_BIN="$(cd $(dirname "$0"); pwd)/../../env/conda/envs/symbiflow_arch_def_base/bin"
-	export F4PGA_ENV_SHARE="$(cd $(dirname "$0"); pwd)/../../install/share/symbiflow"
+  export F4PGA_FAM=xc7
+  export F4PGA_ENV_BIN="$(cd $(dirname "$0"); pwd)/../../env/conda/envs/symbiflow_arch_def_base/bin"
+  export F4PGA_ENV_SHARE="$(cd $(dirname "$0"); pwd)/../../install/share/symbiflow"
 }
 
 echo "----------------------------------------"
@@ -34,32 +34,32 @@ echo "----------------------------------------"
 
 heading "Running installed toolchain tests"
 (
-	pushd build
-	export VPR_NUM_WORKERS=${MAX_CORES}
-	export CTEST_OUTPUT_ON_FAILURE=1
-	ctest -R binary_toolchain_test_xc7* -j${MAX_CORES}
-	popd
+  pushd build
+  export VPR_NUM_WORKERS=${MAX_CORES}
+  export CTEST_OUTPUT_ON_FAILURE=1
+  ctest -R binary_toolchain_test_xc7* -j${MAX_CORES}
+  popd
 )
 echo "----------------------------------------"
 
 heading "Compressing install dir (creating packages)"
 (
-	rm -rf build
+  rm -rf build
 
-	# Remove symbolic links and copy content of the linked files
-	for file in $(find install -type l)
-		do cp --remove-destination $(readlink $file) $file
-	done
+  # Remove symbolic links and copy content of the linked files
+  for file in $(find install -type l)
+    do cp --remove-destination $(readlink $file) $file
+  done
 
-	du -ah install
-	export GIT_HASH=$(git rev-parse --short HEAD)
-	tar -I "pixz" -cvf symbiflow-arch-defs-install-${GIT_HASH}.tar.xz -C install share/symbiflow/techmaps share/symbiflow/scripts environment.yml
-	tar -I "pixz" -cvf symbiflow-arch-defs-benchmarks-${GIT_HASH}.tar.xz -C install benchmarks
-	for device in $(ls install/share/symbiflow/arch)
-	do
-		tar -I "pixz" -cvf symbiflow-arch-defs-$device-${GIT_HASH}.tar.xz -C install share/symbiflow/arch/$device
-	done
-	rm -rf install
+  du -ah install
+  export GIT_HASH=$(git rev-parse --short HEAD)
+  tar -I "pixz" -cvf symbiflow-arch-defs-install-${GIT_HASH}.tar.xz -C install share/symbiflow/techmaps share/symbiflow/scripts environment.yml
+  tar -I "pixz" -cvf symbiflow-arch-defs-benchmarks-${GIT_HASH}.tar.xz -C install benchmarks
+  for device in $(ls install/share/symbiflow/arch)
+  do
+    tar -I "pixz" -cvf symbiflow-arch-defs-$device-${GIT_HASH}.tar.xz -C install share/symbiflow/arch/$device
+  done
+  rm -rf install
 )
 echo "----------------------------------------"
 
@@ -67,12 +67,12 @@ GCP_PATH=symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/
 
 heading "Uploading packages"
 (
-    if [ "$UPLOAD_PACKAGES" != "true" ]; then
-        echo "Not uploading packages as not requested by the CI"
-        exit 0
-    fi
-    TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
-    echo "> Timestamp: $TIMESTAMP"
-    for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
+  if [ "$UPLOAD_PACKAGES" != "true" ]; then
+    echo "Not uploading packages as not requested by the CI"
+    exit 0
+  fi
+  TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
+  echo "> Timestamp: $TIMESTAMP"
+  for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
 )
 echo "----------------------------------------"

--- a/.github/ci/install.sh
+++ b/.github/ci/install.sh
@@ -73,6 +73,10 @@ heading "Uploading packages"
   fi
   TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
   echo "> Timestamp: $TIMESTAMP"
+
+  echo 'Timestamp: $TIMESTAMP' >> $GITHUB_STEP_SUMMARY
+  echo 'Hash: '"$(echo ${package} | sed 's/.*-\(.*\)\.tar\.xz/\1/')" >> $GITHUB_STEP_SUMMARY
+
   for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
 )
 echo "----------------------------------------"

--- a/.github/ci/install.sh
+++ b/.github/ci/install.sh
@@ -67,14 +67,12 @@ GCP_PATH=symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/
 
 heading "Uploading packages"
 (
-    if [ "$UPLOAD_PACKAGES" = "true" ]; then
-        TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
-        for package in $(ls *.tar.xz)
-        do
-            gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/
-        done
-    else
+    if [ "$UPLOAD_PACKAGES" != "true" ]; then
         echo "Not uploading packages as not requested by the CI"
+        exit 0
     fi
+    TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
+    echo "> Timestamp: $TIMESTAMP"
+    for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
 )
 echo "----------------------------------------"


### PR DESCRIPTION
Packages are uploaded to GCS through `gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/`. Unfortunately, the target is hidden in the logs:

https://github.com/SymbiFlow/f4pga-arch-defs/runs/6472094719?check_suite_focus=true#step:4:24660
```
Copying file://symbiflow-arch-defs-xc7a50t-arty-swbut-overlay_test-11aa9fd.tar.xz [Content-Type=application/x-tar]...
```

Therefore, users cannot guess the URL of the arch-def packages generated by some specific commit. They know the format, they know the hash, but they don't know the specific timestamp. This PR prints it.

Ref chipsalliance/f4pga-examples#292