### PR TITLE
ci/install: upload packages in a separated step

### DIFF
--- a/.github/ci/install.sh
+++ b/.github/ci/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 INSTALL_DIR="$(pwd)/install"
 mkdir -p $INSTALL_DIR
@@ -8,18 +8,18 @@ source $(dirname "$0")/setup-and-activate.sh
 
 heading "Installing gsutil"
 (
-    apt -qqy update && apt -qqy install curl
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-    apt -qqy update && apt -qqy install google-cloud-cli
+  apt -qqy update && apt -qqy install curl
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+  apt -qqy update && apt -qqy install google-cloud-cli
 )
 echo "----------------------------------------"
 
 heading "Set environment variables for F4PGA CLI utils"
 {
-	export F4PGA_FAM=xc7
-	export F4PGA_ENV_BIN="$(cd $(dirname "$0"); pwd)/../../env/conda/envs/symbiflow_arch_def_base/bin"
-	export F4PGA_ENV_SHARE="$(cd $(dirname "$0"); pwd)/../../install/share/symbiflow"
+  export F4PGA_FAM=xc7
+  export F4PGA_ENV_BIN="$(cd $(dirname "$0"); pwd)/../../env/conda/envs/symbiflow_arch_def_base/bin"
+  export F4PGA_ENV_SHARE="$(cd $(dirname "$0"); pwd)/../../install/share/symbiflow"
 }
 
 echo "----------------------------------------"
@@ -34,32 +34,32 @@ echo "----------------------------------------"
 
 heading "Running installed toolchain tests"
 (
-	pushd build
-	export VPR_NUM_WORKERS=${MAX_CORES}
-	export CTEST_OUTPUT_ON_FAILURE=1
-	ctest -R binary_toolchain_test_xc7* -j${MAX_CORES}
-	popd
+  pushd build
+  export VPR_NUM_WORKERS=${MAX_CORES}
+  export CTEST_OUTPUT_ON_FAILURE=1
+  ctest -R binary_toolchain_test_xc7* -j${MAX_CORES}
+  popd
 )
 echo "----------------------------------------"
 
 heading "Compressing install dir (creating packages)"
 (
-	rm -rf build
+  rm -rf build
 
-	# Remove symbolic links and copy content of the linked files
-	for file in $(find install -type l)
-		do cp --remove-destination $(readlink $file) $file
-	done
+  # Remove symbolic links and copy content of the linked files
+  for file in $(find install -type l)
+    do cp --remove-destination $(readlink $file) $file
+  done
 
-	du -ah install
-	export GIT_HASH=$(git rev-parse --short HEAD)
-	tar -I "pixz" -cvf symbiflow-arch-defs-install-${GIT_HASH}.tar.xz -C install share/symbiflow/techmaps share/symbiflow/scripts environment.yml
-	tar -I "pixz" -cvf symbiflow-arch-defs-benchmarks-${GIT_HASH}.tar.xz -C install benchmarks
-	for device in $(ls install/share/symbiflow/arch)
-	do
-		tar -I "pixz" -cvf symbiflow-arch-defs-$device-${GIT_HASH}.tar.xz -C install share/symbiflow/arch/$device
-	done
-	rm -rf install
+  du -ah install
+  export GIT_HASH=$(git rev-parse --short HEAD)
+  tar -I "pixz" -cvf symbiflow-arch-defs-install-${GIT_HASH}.tar.xz -C install share/symbiflow/techmaps share/symbiflow/scripts environment.yml
+  tar -I "pixz" -cvf symbiflow-arch-defs-benchmarks-${GIT_HASH}.tar.xz -C install benchmarks
+  for device in $(ls install/share/symbiflow/arch)
+  do
+    tar -I "pixz" -cvf symbiflow-arch-defs-$device-${GIT_HASH}.tar.xz -C install share/symbiflow/arch/$device
+  done
+  rm -rf install
 )
 echo "----------------------------------------"
 
@@ -67,12 +67,12 @@ GCP_PATH=symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/
 
 heading "Uploading packages"
 (
-    if [ "$UPLOAD_PACKAGES" != "true" ]; then
-        echo "Not uploading packages as not requested by the CI"
-        exit 0
-    fi
-    TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
-    echo "> Timestamp: $TIMESTAMP"
-    for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
+  if [ "$UPLOAD_PACKAGES" != "true" ]; then
+    echo "Not uploading packages as not requested by the CI"
+    exit 0
+  fi
+  TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
+  echo "> Timestamp: $TIMESTAMP"
+  for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
 )
 echo "----------------------------------------"

--- a/.github/ci/install.sh
+++ b/.github/ci/install.sh
@@ -73,6 +73,10 @@ heading "Uploading packages"
   fi
   TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
   echo "> Timestamp: $TIMESTAMP"
+
+  echo 'Timestamp: $TIMESTAMP' >> $GITHUB_STEP_SUMMARY
+  echo 'Hash: '"$(echo ${package} | sed 's/.*-\(.*\)\.tar\.xz/\1/')" >> $GITHUB_STEP_SUMMARY
+
   for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
 )
 echo "----------------------------------------"

--- a/.github/ci/install.sh
+++ b/.github/ci/install.sh
@@ -67,14 +67,12 @@ GCP_PATH=symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/
 
 heading "Uploading packages"
 (
-    if [ "$UPLOAD_PACKAGES" = "true" ]; then
-        TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
-        for package in $(ls *.tar.xz)
-        do
-            gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/
-        done
-    else
+    if [ "$UPLOAD_PACKAGES" != "true" ]; then
         echo "Not uploading packages as not requested by the CI"
+        exit 0
     fi
+    TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
+    echo "> Timestamp: $TIMESTAMP"
+    for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
 )
 echo "----------------------------------------"

--- a/.github/ci/install.sh
+++ b/.github/ci/install.sh
@@ -62,21 +62,3 @@ heading "Compressing install dir (creating packages)"
   rm -rf install
 )
 echo "----------------------------------------"
-
-GCP_PATH=symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install
-
-heading "Uploading packages"
-(
-  if [ "$UPLOAD_PACKAGES" != "true" ]; then
-    echo "Not uploading packages as not requested by the CI"
-    exit 0
-  fi
-  TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
-  echo "> Timestamp: $TIMESTAMP"
-
-  echo 'Timestamp: $TIMESTAMP' >> $GITHUB_STEP_SUMMARY
-  echo 'Hash: '"$(echo ${package} | sed 's/.*-\(.*\)\.tar\.xz/\1/')" >> $GITHUB_STEP_SUMMARY
-
-  for package in $(ls *.tar.xz); do gsutil cp ${package} gs://${GCP_PATH}/${TIMESTAMP}/; done
-)
-echo "----------------------------------------"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -64,7 +64,6 @@ jobs:
       MAX_CORES: 80
       GHA_EXTERNAL_DISK: "tools"
       GHA_SA: "gh-sa-f4pga-arch-defs-ci"
-      UPLOAD_PACKAGES: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
     steps:
 
@@ -75,6 +74,20 @@ jobs:
 
       - name: '🚧 Execute test script'
         run: stdbuf -i0 -o0 -e0 ./.github/ci/install.sh
+
+      - name: 🚀 Upload to Google Cloud Storage (GCS) bucket
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        run: |
+          TIMESTAMP=$(date +'%Y%m%d-%H%M%S')
+          echo "> Timestamp: $TIMESTAMP"
+
+          echo 'Timestamp: $TIMESTAMP' >> $GITHUB_STEP_SUMMARY
+          echo 'Hash: '"$(echo ${package} | sed 's/.*-\(.*\)\.tar\.xz/\1/')" >> $GITHUB_STEP_SUMMARY
+
+          for package in $(ls *.tar.xz); do
+            gsutil cp ${package} \
+              gs://symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${TIMESTAMP}/
+          done
 
       - name: '📤 Upload artifact: results and plot'
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR is based on #2674.

Instead of uploading the packages to the GCS at the end of script `.github/ci/install.sh`, those 5-7 lines of code are written as an additional step in the CI workflow. This is to make it easier for users/contributors to find the packages uploaded by a CI run.