### PR TITLE
Inherit secrets in Tests.yml

### DIFF
--- a/.github/workflows/Automerge.yml
+++ b/.github/workflows/Automerge.yml
@@ -10,6 +10,7 @@ jobs:
   Pipeline:
     if: ${{ !(github.event_name != 'pull_request' && github.actor == 'dependabot[bot]') }}
     uses: ./.github/workflows/Tests.yml
+    secrets: inherit 
 
 
   Automerge:


### PR DESCRIPTION
This pull request fixes the bug in CI where the `GCP_STORAGE_BUCKET` was missing and was causing the Install job to fail.

It's not possible to prove that this fix works by looking at the CI jobs executed by this pull request, so I prepared a [test branch](https://github.com/SymbiFlow/f4pga-arch-defs/commits/test-secrets) that demonstrates that after adding the secret inheritance policy, the secret is passed. I'll remove that branch if the fix works on main after this PR gets merged in.

I'm leaving some links to the documentation that describes using secrets and inputs in reusable workflows:
* https://docs.github.com/en/actions/using-workflows/reusing-workflows
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets