### PR TITLE
requirements: Loosen `pycapnp` version constraint to fix the conflict

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,6 +37,7 @@ dependencies:
   # the python library in the conda environment before running pip. Unclear when this can be removed,
   # possibly upon further setuptools or pkg-config updates.
   - packaging=21.3
-  - pip
+  # Newer Pip, particularly v21.2.2, has broken dependency conflict reporting.
+  - pip=21.1.3
   - pip:
     - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy
 pdfminer.six
 ply
 progressbar2
-pycapnp==1.0.0b1
+pycapnp
 pyjson5
 pytest
 python-constraint


### PR DESCRIPTION
`python-fpga-interchange` requires v1.1.0:
https://github.com/chipsalliance/python-fpga-interchange/blob/27fc1db2a37f5e224396c50f0770ea0caef708d9/requirements.txt
so there's a conflict.

Also let's use Pip v21.1.3 instead of the latest; its output for the conflicts is almost instant and great:
https://github.com/antmicro/f4pga-arch-defs/runs/7114351446?check_suite_focus=true#step:3:736
compared to 3.5h it takes v21.2.2 to fail during conflict resolution:
https://github.com/SymbiFlow/f4pga-arch-defs/runs/7105019813?check_suite_focus=true#step:3:906