### PR TITLE
ci/GCS: install gnupg2

### DIFF
--- a/.github/workflows/Automerge.yml
+++ b/.github/workflows/Automerge.yml
@@ -55,7 +55,7 @@ jobs:
       - name: '🛠️ Setup Python and gsutil'
         run: |
           apt update -qqy
-          apt install -qqy curl python3
+          apt install -qqy curl python3 gnupg2
           echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
           curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
           apt update -qqy


### PR DESCRIPTION
The `GCS` job is failing, reportedly due to _coordinator <-> worker_ connectivity issues. Together with @kamilrakoczy we have investigated this and we discovered that it is actually not the OpenSSH process that is failing and returning the 255 exit but the underlying command (to be precise, it is `apt-key` specifically; see `apt-key` [source code](https://git.launchpad.net/ubuntu/+source/apt/tree/cmdline/apt-key.in?h=applied/ubuntu/bionic&id=93d330ad1a7475675fda8c575f7097d82898eb67#n679)).

The following message is produced by the custom runner:
> This error indicates issues with communication with the worker instance.

In most cases it is fair to assume that the 255 exit code is coming from OpenSSH. Anecdotally, programs don't usually use such high exit code and the OpenSSH seems to have taken the liberty of reserving this code to indicate internal failures.

As per `ssh` [manpage](https://linux.die.net/man/1/ssh):
> ssh exits with the exit status of the remote command or with 255 if an error occurred.

In this case, however, it is misleading as 255 was **not** produced by `ssh` but rather was a legitimate exit code code coming from the underlying process. This means that we (custom runners development team) must rethink how to indicate connection failures and how to discriminate ssh failures from legitimate failures.

This pull request solves the original problem -- meaning lack of `gnupg`.

We reproduced this issue (and the fix for it) on our test bed repository for runners. See [before](https://github.com/antmicro/github-runner-test/actions/runs/2648926012) and [after](https://github.com/antmicro/github-runner-test/actions/runs/2648944413).