### PR TITLE
xilinx/xc7/tests/install_test/Makefile: use '--' to separate additional VPR options

### DIFF
--- a/xilinx/xc7/tests/install_test/Makefile
+++ b/xilinx/xc7/tests/install_test/Makefile
@@ -25,16 +25,16 @@ ${BUILDDIR}/${TOP}.eblif: | ${BUILDDIR}
 	cd ${BUILDDIR} && symbiflow_synth -t ${TOP} ${SURELOG_OPT} -v ${VERILOG} -d ${BITSTREAM_DEVICE} -p ${PARTNAME} -x ${XDC}
 
 ${BUILDDIR}/${TOP}.net: ${BUILDDIR}/${TOP}.eblif
-	cd ${BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -a ${ADDITIONAL_VPR_OPTIONS}
+	cd ${BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -- ${ADDITIONAL_VPR_OPTIONS}
 
 ${BUILDDIR}/${TOP}.place: ${BUILDDIR}/${TOP}.net
-	cd ${BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -n ${TOP}.net -P ${PARTNAME} -a ${ADDITIONAL_VPR_OPTIONS}
+	cd ${BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -n ${TOP}.net -P ${PARTNAME} -- ${ADDITIONAL_VPR_OPTIONS}
 
 ${BUILDDIR}/${TOP}.route: ${BUILDDIR}/${TOP}.place
-	cd ${BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -a ${ADDITIONAL_VPR_OPTIONS}
+	cd ${BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -- ${ADDITIONAL_VPR_OPTIONS}
 
 ${BUILDDIR}/${TOP}.fasm: ${BUILDDIR}/${TOP}.route
-	cd ${BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE} --additional_vpr_options ${ADDITIONAL_VPR_OPTIONS}
+	cd ${BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE} -- ${ADDITIONAL_VPR_OPTIONS}
 
 ${BUILDDIR}/${TOP}.bit: ${BUILDDIR}/${TOP}.fasm
 	cd ${BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit


### PR DESCRIPTION
Required because of https://github.com/chipsalliance/f4pga/pull/614.
Ref: #1682.